### PR TITLE
separate failure queues by job

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -33,3 +33,6 @@ redis = Redis.new(host: Settings.redis.hostname,
                   db: Settings.redis.db)
 
 Resque.redis = Redis::Namespace.new(Settings.redis.namespace, redis: redis)
+
+# configure a separate failure queue per job queue
+Resque::Failure.backend = Resque::Failure::RedisMultiQueue


### PR DESCRIPTION
## Why was this change made?

Mostly to be able to view and clear failures by a specific queue.  See https://preservation-catalog-prod-01.stanford.edu/resque/failed for an example and compare with https://robot-console-prod.stanford.edu/failed.

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a