### PR TITLE
no need to lock to Capistrano release

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid for current version and patch releases of Capistrano
-lock '~> 3.11.0'
+# lock '~> 3.12.0'
 
 set :application, 'robot-console'
 set :repo_url, 'https://github.com/sul-dlss/robot-console.git'


### PR DESCRIPTION
## Why was this change made?

To get past this:

```sh
$ bundle exec cap stage deploy
(Backtrace restricted to imported tasks)
cap aborted!
Capfile locked at ~> 3.11.0, but 3.12.0 is loaded
```

Note that very few of our projects lock to a capistrano release:

```sh
$ ack lock ../*/config/deploy.rb
../dlme-harvest/config/deploy.rb
4:lock '~> 3.11.0'

../robot-console/config/deploy.rb
2:lock '~> 3.12.0'

../searchworks/config/deploy.rb
2:lock '3.4.0'

../sul_styles/config/deploy.rb
2:lock '3.4.0'

../workflow-server-rails/config/deploy.rb
4:lock '~> 3.11.0'
```

## Was the usage documentation (e.g. wiki, README) updated?

n/a