### PR TITLE
update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,10 @@
 
 
 
-## Was the usage documentation (e.g. wiki, README) updated?
+## How was this change tested?
+- test code in this repo, infra-integration-tests, manually on [laptop|stage|qa], vetted by PO in [stage|qa] ...
+
+
+
+## Which documentation and/or configurations were updated?
+- README, DevOpsDocs, shared_configs, wiki, ...


### PR DESCRIPTION
## Why was this change made?

in the hopes of getting
- better communication between PR author and reviewers
- better "stop and think" moments about testing and documentation from both PR authors and reviewers

## How was this change tested?
- test code in this repo, infra-integration-tests, manually on [laptop|stage|qa], vetted by PO in [stage|qa] ...

I asked for review of the new template from infrastructure team

## Which documentation and/or configurations were updated?
- README, DevOpsDocs, shared_configs, wiki, ...

n/a