### PR TITLE
Add capistrano-rvm to fix deployment issue where bundler is not found

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -28,7 +28,7 @@ install_plugin Capistrano::SCM::Git
 #   https://github.com/capistrano/rails
 #   https://github.com/capistrano/passenger
 #
-# require "capistrano/rvm"
+require "capistrano/rvm"
 # require "capistrano/rbenv"
 # require "capistrano/chruby"
 require 'capistrano/bundler'

--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,6 @@ end
 
 group :development do
   gem 'capistrano-passenger', require: false
+  gem 'capistrano-rvm', require: false
   gem 'dlss-capistrano', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,9 @@ GEM
       capistrano (~> 3.0)
     capistrano-passenger (0.2.1)
       capistrano (~> 3.0)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     concurrent-ruby (1.1.10)
     config (4.0.0)
@@ -124,6 +127,7 @@ PLATFORMS
 
 DEPENDENCIES
   capistrano-passenger
+  capistrano-rvm
   config
   dlss-capistrano
   honeybadger
@@ -131,4 +135,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.2.15
+   2.3.13


### PR DESCRIPTION
## Why was this change made?

To fix the deployment to ubuntu VMs.

## How was this change tested?

Deployed to stage.
