### PR TITLE
set honeybadger env to the capistrano deployment stage

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -38,3 +38,6 @@ set :deploy_to, '/opt/app/robot-console/robot-console'
 
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
+
+# honeybadger_env otherwise defaults to rails_env
+set :honeybadger_env, fetch(:stage)


### PR DESCRIPTION
so that we don't default to `production` for every deploy (there's no rails_env to fetch since this isn't a rails app)

## Why was this change made?

noticed this morning when double-checking dependency update deployments to stage that all our robot-console deployments are defaulting to `production` (which isn't an actual env for this app).  conveniently, i noticed the fix when reviewing [another PR](https://github.com/sul-dlss/was-pywb/pull/48/files) later this afternoon.

## How was this change tested?

i deployed this branch to stage, and honeybadger correctly reported the deployed branch as `stage` instead of as `production` (as had happened on prior deploys).

a bunch of deployments recorded in honeybadger, the second most recent of which was definitely made to stage this morning (i compared against `revisions.log` on the VM), the most recent of which shows the correct env name because it used this branch:
<img width="434" alt="Screen Shot 2022-06-20 at 5 52 53 PM" src="https://user-images.githubusercontent.com/7741604/174694655-733014a5-1f74-4383-abe1-27407a84d418.png">


for comparison, the deployment history of dor_indexing_app, which correctly uses our standard `prod` instead of `production`  (this app follows that convention too, see `config/deploy/`).
<img width="437" alt="Screen Shot 2022-06-20 at 5 53 05 PM" src="https://user-images.githubusercontent.com/7741604/174694672-98e32379-d66d-47fa-b82f-dd27da0c22de.png">
