### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -28,9 +28,6 @@ install_plugin Capistrano::SCM::Git
 #   https://github.com/capistrano/rails
 #   https://github.com/capistrano/passenger
 #
-require "capistrano/rvm"
-# require "capistrano/rbenv"
-# require "capistrano/chruby"
 require 'capistrano/bundler'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,5 @@ end
 
 group :development do
   gem 'capistrano-passenger', require: false
-  gem 'capistrano-rvm', require: false
   gem 'dlss-capistrano', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,9 +22,6 @@ GEM
       capistrano (~> 3.0)
     capistrano-passenger (0.2.1)
       capistrano (~> 3.0)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     concurrent-ruby (1.1.10)
     config (4.0.0)
@@ -128,7 +125,6 @@ PLATFORMS
 
 DEPENDENCIES
   capistrano-passenger
-  capistrano-rvm
   config
   dlss-capistrano
   honeybadger
@@ -137,4 +133,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.3.17
+   2.3.22


### PR DESCRIPTION
## Why was this change made?

This commit removes capistrano-rvm, a dependency we no longer need. Done because it is on the FR board.



## How was this change tested?

Tested by deploying to stage
