### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -6,7 +6,6 @@
 # You can define all roles on a single server, or split them:
 
 server 'robot-console-prod.stanford.edu', user: 'robot-console', roles: %w[app]
-Capistrano::OneTimeKey.generate_one_time_key!
 
 # role-based syntax
 # ==================

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -6,7 +6,6 @@
 # You can define all roles on a single server, or split them:
 
 server 'robot-console-qa.stanford.edu', user: 'robot-console', roles: %w[app]
-Capistrano::OneTimeKey.generate_one_time_key!
 
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -6,7 +6,6 @@
 # You can define all roles on a single server, or split them:
 
 server 'robot-console-stage.stanford.edu', user: 'robot-console', roles: %w[app]
-Capistrano::OneTimeKey.generate_one_time_key!
 
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.