### PR TITLE
explicitly set default external and internal Encodings

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Sidekiq web console fails to render without this, with log entries like:
+#   Exception ArgumentError in Rack application object (invalid byte sequence in US-ASCII)
+# See also https://docs.ruby-lang.org/en/3.4/encodings_rdoc.html
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 require_relative 'config/boot'
 require 'rack/session'
 require 'sidekiq/web'


### PR DESCRIPTION
## Why was this change made?

the sidekiq web console was broken, returning 502 "Incomplete response received from application" responses after the most recent dependency updates (which included a bump from sidekiq 8.1.2 to 8.1.3).  the failed requests corresponded with log entries like `2026-04-22 10:59:53.5704 7547/0x00007f48ce527010(Worker 1) utils.rb ]: *** Exception ArgumentError in Rack application object (invalid byte sequence in US-ASCII) (process 7547, thread 0x00007f48ce527010(Worker 1))`.  restarting and redeploying failed to fix the situation.

when i asked, claude told me to fix it this way 😆 (i mean the reasoning sorta kinda made sense given [the sidekiq diff](https://github.com/sidekiq/sidekiq/compare/v8.1.2...v8.1.3#diff-a19b19d20df90597eaac2e2edc433b5d56d1d30a8501029bfd9688a8980dd150), even though literally all the citations were hallucinated).

this doesn't happen in our rails apps that host a sidekiq dashboard, presumably because rails sets a default encoding of UTF-8.

## How was this change tested?

deployed to stage, was able to pull up sidekiq web console again